### PR TITLE
Fix 'knife solo data bag show -F json' for encrypted data bags

### DIFF
--- a/lib/chef/knife/solo_data_bag_show.rb
+++ b/lib/chef/knife/solo_data_bag_show.rb
@@ -34,7 +34,8 @@ module KnifeSoloDataBag
 
     def bag_item_content
       if should_be_encrypted?
-        Chef::EncryptedDataBagItem.load bag_name, item_name, secret_key
+        raw = Chef::EncryptedDataBagItem.load(bag_name, item_name, secret_key)
+        raw.to_hash
       else
         Chef::DataBagItem.load(bag_name, item_name).raw_data
       end


### PR DESCRIPTION
'show' for an encrypted data bag includes 'stuff' that shouldn't be there. We only need the raw_data.

'knife solo data bag show my_bag my_item --secret-file my_key -F json' fails otherwise since it cannot deserialize the 'stuff' that contains the raw data into json.
