### PR TITLE
Add an option to create a data bag from JSON data in a file

### DIFF
--- a/lib/chef/knife/solo_data_bag_create.rb
+++ b/lib/chef/knife/solo_data_bag_create.rb
@@ -26,6 +26,10 @@ module KnifeSoloDataBag
            :long  => '--json JSON_STRING',
            :description => 'The data bag json string that can be passed at the CLI'
 
+    option :json_file,
+           :long  => '--json-file JSON_FILE',
+           :description => 'A file contining the data bag json string'
+
     option :data_bag_path,
            :long => '--data_bag_path DATA_BAG_PATH',
            :description => 'The path to data bag'
@@ -49,12 +53,16 @@ module KnifeSoloDataBag
 
     def create_item_object
       item = nil
-      if config[:json_string].nil?
+      case
+      when config[:json_string]
+        item = Chef::DataBagItem.from_hash bag_item_content(convert_json_string)
+      when config[:json_file]
+        json_string = JSON.parse(File.read(config[:json_file]))
+        item = Chef::DataBagItem.from_hash bag_item_content(json_string)
+      else
         create_object({'id' => item_name}, "data_bag_item[#{item_name}]") do |output|
           item = Chef::DataBagItem.from_hash bag_item_content(output)
         end
-      else
-        item = Chef::DataBagItem.from_hash bag_item_content(convert_json_string)
       end
       item
     end

--- a/spec/unit/solo_data_bag_create_spec.rb
+++ b/spec/unit/solo_data_bag_create_spec.rb
@@ -195,6 +195,22 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
         end
       end
 
+      context 'when also specifying a json file' do
+        before do
+          @knife.name_args << 'bar'
+          @json_path                = '/var/chef/my_bag.json'
+          @knife.config[:json_file] = @json_path
+          @input_data               = {'id' => 'foo', 'sub' => {'key_1' => 'value_1', 'key_2' => 'value_2'}}
+          @item_path                = "#{@bag_path}/bar.json"
+          File.open(@json_path, 'w') { |f| f.write @input_data.to_json }
+        end
+
+        it 'creates the data bag item' do
+          @knife.run
+          JSON.parse(File.read(@item_path)).raw_data.should == @input_data
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
An option --json-file is added that takes a file path.
I.e.

  $ knife solo data bag create my_bag my_item --json-file foo.json

The file's contents are loaded and used as the contents of the new
data bag.
