### PR TITLE
make tests work with old or recent JSON module serialization behavior.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,20 @@
 require 'fakefs/safe'
 require 'knife-solo_data_bag'
 
+
+def JSON_to_databag_item (json_string)
+  #This is a fix to handle differing JSON behavior across multiple JSON module versions
+  json_parsed = JSON.parse(json_string)
+  #should break these into their own tests depending on JSON::VERSION value?
+  if json_parsed.is_a? Chef::DataBagItem #old JSON deserialized it
+    item = json_parsed
+  elsif json_parsed.has_key?("json_class") #old serialized file format knife-solo_data_bag<=0.4.0
+    item = Chef::DataBagItem.json_create json_parsed #method is destructive to json_parsed
+  else #basic hash from json file
+    item = Chef::DataBagItem.from_hash json_parsed
+  end
+end
+
 ['contexts', 'helpers', 'matchers'].each do |dir|
   Dir[File.expand_path(File.join(File.dirname(__FILE__),dir,'*.rb'))].each {|f| require f}
 end

--- a/spec/unit/solo_data_bag_create_spec.rb
+++ b/spec/unit/solo_data_bag_create_spec.rb
@@ -46,10 +46,11 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
         it 'should create the data bag item' do
           @knife.run
-          JSON.parse(File.read(@item_path)).raw_data.should == @input_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          item.raw_data.should == @input_data
         end
 
-        context 'with --data-bag-path' do
+        context 'with --data/-bag-path' do
           before do
             @override_bags_path           = '/opt/bags'
             @override_bag_path            = "#{@override_bags_path}/bag_1"
@@ -71,7 +72,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'should create the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -91,7 +93,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'should create the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -112,7 +115,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'creates the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -133,7 +137,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
         it 'should create the data bag item' do
           @knife.run
-          JSON.parse(File.read(@item_path)).raw_data.should == @input_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          item.raw_data.should == @input_data
         end
 
         context 'when encrypting with -s or --secret' do
@@ -144,7 +149,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'should create the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -164,7 +170,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'should create the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -185,7 +192,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
           it 'creates the encrypted data bag item' do
             @knife.run
-            content = JSON.parse(File.read(@item_path)).raw_data
+            item = JSON_to_databag_item(File.read(@item_path))
+            content = item.raw_data
             @input_data.keys.reject{|i| i == 'id'}.each do |k|
               content.should have_key k
               content[k].should_not == @input_data[k]
@@ -207,7 +215,8 @@ describe KnifeSoloDataBag::SoloDataBagCreate do
 
         it 'creates the data bag item' do
           @knife.run
-          JSON.parse(File.read(@item_path)).raw_data.should == @input_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          item.raw_data.should == @input_data
         end
       end
 

--- a/spec/unit/solo_data_bag_edit_spec.rb
+++ b/spec/unit/solo_data_bag_edit_spec.rb
@@ -55,7 +55,8 @@ describe KnifeSoloDataBag::SoloDataBagEdit do
 
       it 'should edit the data bag item' do
         @knife.run
-        JSON.parse(File.read(@item_path)).raw_data.should == @updated_data
+        item = JSON_to_databag_item(File.read(@item_path))
+        item.raw_data.should == @updated_data
       end
 
       it 'should write pretty json' do
@@ -83,7 +84,8 @@ describe KnifeSoloDataBag::SoloDataBagEdit do
 
         it 'uses the data bag path from the override' do
           @knife.run
-          data = JSON.parse(File.read(@override_item_path)).raw_data
+          item = JSON_to_databag_item(File.read(@override_item_path))
+          data = item.raw_data
           data.should == @updated_data
         end
       end
@@ -98,7 +100,8 @@ describe KnifeSoloDataBag::SoloDataBagEdit do
 
         it 'should edit the encrypted data bag item' do
           @knife.run
-          content = JSON.parse(File.read(@item_path)).raw_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          content = item.raw_data
           content['who'].should_not == @orig_data['who']
           content['who'].should_not be_nil
         end
@@ -118,7 +121,8 @@ describe KnifeSoloDataBag::SoloDataBagEdit do
 
         it 'should edit the encrypted data bag item' do
           @knife.run
-          content = JSON.parse(File.read(@item_path)).raw_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          content = item.raw_data
           content['who'].should_not == @orig_data['who']
           content['who'].should_not be_nil
         end
@@ -140,7 +144,8 @@ describe KnifeSoloDataBag::SoloDataBagEdit do
 
         it 'should edit the encrypted data bag item' do
           @knife.run
-          content = JSON.parse(File.read(@item_path)).raw_data
+          item = JSON_to_databag_item(File.read(@item_path))
+          content = item.raw_data
           content['who'].should_not == @orig_data['who']
           content['who'].should_not be_nil
         end


### PR DESCRIPTION
This will revise tests to run on various JSON module versions and also compensate for the differing behavior so that it may pass. It should be added with the related pull request https://github.com/thbishop/knife-solo_data_bag/pull/12
