### PR TITLE
stub for Chef::DataBagItem #save method.

### DIFF
--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -34,7 +34,11 @@ module KnifeSoloDataBag
     private
     def edit_content
       updated_content = edit_data existing_bag_item_content
-      item = Chef::DataBagItem.from_hash format_editted_content(updated_content)
+      update_bag_item updated_content
+    end
+
+    def update_bag_item(new_content)
+      item = Chef::DataBagItem.from_hash format_editted_content(new_content)
       item.data_bag bag_name
       persist_bag_item item
     end

--- a/lib/chef/solo_data_bag_item.rb
+++ b/lib/chef/solo_data_bag_item.rb
@@ -1,0 +1,7 @@
+class Chef::DataBagItem
+
+  def save
+    KnifeSoloDataBag::SoloDataBagEdit.new('redis', 'master').send(:update_bag_item, self.to_json)
+  end
+
+end

--- a/lib/chef/solo_data_bag_item.rb
+++ b/lib/chef/solo_data_bag_item.rb
@@ -1,7 +1,11 @@
 class Chef::DataBagItem
 
   def save
-    KnifeSoloDataBag::SoloDataBagEdit.new([self.data_bag, self.name]).send(:update_bag_item, self.to_json)
+    Chef::Config[:solo] = true
+    data_bag_item = KnifeSoloDataBag::SoloDataBagEdit.new([self.data_bag, self.name])
+    data_bag_item.instance_variable_set :@bag_name, self.data_bag
+    data_bag_item.instance_variable_set :@item_name, self.name
+    data_bag_item.send(:update_bag_item, self.to_hash)
   end
 
 end

--- a/lib/chef/solo_data_bag_item.rb
+++ b/lib/chef/solo_data_bag_item.rb
@@ -1,10 +1,10 @@
 class Chef::DataBagItem
 
-  def save
+  def save(item_id = @raw_data['id'])
     Chef::Config[:solo] = true
-    data_bag_item = KnifeSoloDataBag::SoloDataBagEdit.new([self.data_bag, self.name])
+    data_bag_item = KnifeSoloDataBag::SoloDataBagEdit.new([self.data_bag, item_id])
     data_bag_item.instance_variable_set :@bag_name, self.data_bag
-    data_bag_item.instance_variable_set :@item_name, self.name
+    data_bag_item.instance_variable_set :@item_name, item_id
     data_bag_item.send(:update_bag_item, self.to_hash)
   end
 

--- a/lib/chef/solo_data_bag_item.rb
+++ b/lib/chef/solo_data_bag_item.rb
@@ -1,7 +1,7 @@
 class Chef::DataBagItem
 
   def save
-    KnifeSoloDataBag::SoloDataBagEdit.new('redis', 'master').send(:update_bag_item, self.to_json)
+    KnifeSoloDataBag::SoloDataBagEdit.new([self.data_bag, self.name]).send(:update_bag_item, self.to_json)
   end
 
 end

--- a/lib/knife-solo_data_bag.rb
+++ b/lib/knife-solo_data_bag.rb
@@ -5,6 +5,7 @@ require 'chef/knife/solo_data_bag_edit'
 require 'chef/knife/solo_data_bag_list'
 require 'chef/knife/solo_data_bag_show'
 require 'knife-solo_data_bag/version'
+require 'chef/solo_data_bag_item'
 
 module Knife
   module SoloDataBag; end


### PR DESCRIPTION
I want to have ability to save DataBagItem inside my chef scripts. Something like this: 

``` ruby
redis_master_config = Chef::DataBagItem.load('redis', 'master')
redis_master_config['address'] = @master['address']
redis_master_config.save
```

PR is my quick work around. 

@thbishop what do you think about it ?
