### PR TITLE
Handle different error classes for malformed JSON

### DIFF
--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -43,7 +43,13 @@ class Chef
           begin
             updated_content = Chef::JSONCompat.from_json(unparsed)
             break
-          rescue Yajl::ParseError => e
+          rescue => e
+            case
+            when (Object.const_defined?('::Yajl::ParseError') && e.is_a?(Yajl::ParseError))
+            when (Object.const_defined?('::FFI_Yajl::ParseError') && e.is_a?(FFI_Yajl::ParseError))
+            else
+              raise e
+            end
             loop do
               ui.stdout.puts e.to_s
               question = "Do you want to keep editing (Y/N)? If you choose 'N', all changes will be lost"

--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -45,8 +45,16 @@ class Chef
             break
           rescue => e
             case
-            when (Object.const_defined?('::Yajl::ParseError') && e.is_a?(Yajl::ParseError))
-            when (Object.const_defined?('::FFI_Yajl::ParseError') && e.is_a?(FFI_Yajl::ParseError))
+            when (
+              Object.const_defined?('Yajl') &&
+              Yajl.const_defined?('ParseError') &&
+              e.is_a?(Yajl::ParseError)
+            )
+            when (
+              Object.const_defined?('FFI_Yajl') &&
+              FFI_Yajl.const_defined?('ParseError') &&
+              e.is_a?(FFI_Yajl::ParseError)
+            )
             else
               raise e
             end

--- a/spec/unit/solo_data_bag_edit_spec.rb
+++ b/spec/unit/solo_data_bag_edit_spec.rb
@@ -195,9 +195,15 @@ describe Chef::Knife::SoloDataBagEdit do
           let(:user_wants_to_reedit) { 'N' }
           let(:error_class) do
             case
-            when Object.const_defined?('::Yajl::ParseError')
+            when (
+              Object.const_defined?('Yajl') &&
+              Yajl.const_defined?('ParseError')
+            )
               Yajl::ParseError
-            when Object.const_defined?('::FFI_Yajl::ParseError')
+            when (
+              Object.const_defined?('FFI_Yajl') &&
+              FFI_Yajl.const_defined?('ParseError')
+            )
               FFI_Yajl::ParseError
             else
               StandardError

--- a/spec/unit/solo_data_bag_edit_spec.rb
+++ b/spec/unit/solo_data_bag_edit_spec.rb
@@ -193,11 +193,21 @@ describe Chef::Knife::SoloDataBagEdit do
 
         context "the user doesn't want to re-edit" do
           let(:user_wants_to_reedit) { 'N' }
+          let(:error_class) do
+            case
+            when Object.const_defined?('::Yajl::ParseError')
+              Yajl::ParseError
+            when Object.const_defined?('::FFI_Yajl::ParseError')
+              FFI_Yajl::ParseError
+            else
+              StandardError
+            end
+          end
 
           it 'an error is thrown' do
             lambda {
               @knife.run
-            }.should raise_error(Yajl::ParseError)
+            }.should raise_error(error_class)
           end
         end
       end


### PR DESCRIPTION
Older Chef versions used Yajl, newer use FFI_Yajl, without
this fix the rescue statement raises an undefined constant
error.
