### PR TITLE
Fixing 'knife solo data bag edit' crashes when edited data is invalid.

### DIFF
--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'chef/knife'
+require 'yajl'
 
 class Chef
   class Knife


### PR DESCRIPTION
Without this fix, the following error occurred on my machine, when invalid JSON was put into the data bag:

```
$ knife solo data bag edit main bag -VV --secret-file test/integration/default/encrypted_data_bag_secret --data-bag-path test/integration/default/data_bags
ffi-yajl/json_gem is deprecated, these monkeypatches will be dropped shortly
WARNING: The encrypted_data_bag_secret option defined in knife.rb was overriden by the command line.
/var/lib/gems/1.9.1/gems/knife-solo_data_bag-1.1.0/lib/chef/knife/solo_data_bag_edit.rb:46:in `rescue in block in edit_content': uninitialized constant Chef::Knife::SoloDataBagEdit::Yajl (NameError)
    from /var/lib/gems/1.9.1/gems/knife-solo_data_bag-1.1.0/lib/chef/knife/solo_data_bag_edit.rb:43:in `block in edit_content'
    from /var/lib/gems/1.9.1/gems/knife-solo_data_bag-1.1.0/lib/chef/knife/solo_data_bag_edit.rb:41:in `loop'
    from /var/lib/gems/1.9.1/gems/knife-solo_data_bag-1.1.0/lib/chef/knife/solo_data_bag_edit.rb:41:in `edit_content'
    from /var/lib/gems/1.9.1/gems/knife-solo_data_bag-1.1.0/lib/chef/knife/solo_data_bag_edit.rb:34:in `run'
    from /var/lib/gems/1.9.1/gems/chef-11.14.6/lib/chef/knife.rb:493:in `run_with_pretty_exceptions'
    from /var/lib/gems/1.9.1/gems/chef-11.14.6/lib/chef/knife.rb:174:in `run'
    from /var/lib/gems/1.9.1/gems/chef-11.14.6/lib/chef/application/knife.rb:139:in `run'
    from /var/lib/gems/1.9.1/gems/chef-11.14.6/bin/knife:25:in `<top (required)>'
    from /usr/local/bin/knife:23:in `load'
    from /usr/local/bin/knife:23:in `<main>'
```
