### PR TITLE
Enable solo_legacy_mode for for Chef >= 12.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ gemfile:
   - ./gemfiles/Gemfile.chef.11.10.0
   - ./gemfiles/Gemfile.chef.11.10.2
   - ./gemfiles/Gemfile.chef.11.10.4
+  - ./gemfiles/Gemfile.chef.12.12.15

--- a/gemfiles/Gemfile.chef.12.12.15
+++ b/gemfiles/Gemfile.chef.12.12.15
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'chef', '12.12.15'
+
+gemspec :path => "../"

--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -29,6 +29,7 @@ class Chef
 
       def run
         Chef::Config[:solo]   = true
+        Chef::Config[:solo_legacy_mode] = true
         @bag_name, @item_name = @name_args
         ensure_valid_arguments
         edit_content

--- a/lib/chef/knife/solo_data_bag_show.rb
+++ b/lib/chef/knife/solo_data_bag_show.rb
@@ -28,6 +28,7 @@ class Chef
 
       def run
         Chef::Config[:solo]   = true
+        Chef::Config[:solo_legacy_mode] = true
         @bag_name, @item_name = @name_args
         ensure_valid_arguments
         display_content


### PR DESCRIPTION
Fixes https://github.com/thbishop/knife-solo_data_bag/issues/36.

`Chef::Config[:solo_legacy_mode]` needs to be enabled in order for this plugin to work (unless we do a significant refactor).

See Chef's [release notes for 12.11](https://docs.chef.io/release/12-11/release_notes.html#replace-previous-chef-solo-behavior-with-chef-client-local-mode) for a mention of the change to chef-solo behavior.
