### PR TITLE
Feature/improve malformed json error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 rvm:
   - 1.9.3
 
+before_install:
+  - gem install bundler
+
 gemfile:
-  - ./gemfiles/Gemfile.chef.11.4.4
   - ./gemfiles/Gemfile.chef.11.6.2
   - ./gemfiles/Gemfile.chef.11.8.0
   - ./gemfiles/Gemfile.chef.11.8.2

--- a/gemfiles/Gemfile.chef.11.4.4
+++ b/gemfiles/Gemfile.chef.11.4.4
@@ -1,5 +1,0 @@
-source "http://rubygems.org"
-
-gem 'chef', '11.4.4'
-
-gemspec :path => "../"

--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -43,7 +43,8 @@ class Chef
           begin
             updated_content = Chef::JSONCompat.from_json(unparsed)
             break
-          rescue Yajl::ParseError => e
+          rescue => e
+            raise e if !is_invalid_json_error?(e)
             loop do
               ui.stdout.puts e.to_s
               question = "Do you want to keep editing (Y/N)? If you choose 'N', all changes will be lost"
@@ -103,6 +104,10 @@ class Chef
           ui.fatal 'You must supply a name for the item'
           exit 1
         end
+      end
+
+      def is_invalid_json_error?(exception)
+        exception.class.to_s.end_with?("::ParseError")
       end
 
     end

--- a/spec/unit/solo_data_bag_edit_spec.rb
+++ b/spec/unit/solo_data_bag_edit_spec.rb
@@ -197,7 +197,7 @@ describe Chef::Knife::SoloDataBagEdit do
           it 'an error is thrown' do
             lambda {
               @knife.run
-            }.should raise_error(Yajl::ParseError)
+            }.should raise_error
           end
         end
       end


### PR DESCRIPTION
Resolves the problem of depending on specific exception classes when rescuing from JSON parse errors on save.

The commit also modifies the TravisCI test setup as master not longer works as is.