### PR TITLE
Enable solo_legacy_mode for for Chef >= 12.11

### DIFF
--- a/lib/chef/knife/solo_data_bag_edit.rb
+++ b/lib/chef/knife/solo_data_bag_edit.rb
@@ -29,6 +29,7 @@ class Chef
 
       def run
         Chef::Config[:solo]   = true
+        Chef::Config[:solo_legacy_mode] = true if Gem.loaded_specs['chef'].version > Gem::Version.new('12.11.0')
         @bag_name, @item_name = @name_args
         ensure_valid_arguments
         edit_content

--- a/lib/chef/knife/solo_data_bag_show.rb
+++ b/lib/chef/knife/solo_data_bag_show.rb
@@ -28,6 +28,7 @@ class Chef
 
       def run
         Chef::Config[:solo]   = true
+        Chef::Config[:solo_legacy_mode] = true if Gem.loaded_specs['chef'].version > Gem::Version.new('12.11.0')
         @bag_name, @item_name = @name_args
         ensure_valid_arguments
         display_content


### PR DESCRIPTION
Adapted fix from #37 in a backwards-compatible version.